### PR TITLE
feat: major upgrade adding `multi-tqdm` support, one for each worker 

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ as well as to handle common issues such as:
 
 ## goals
 - [x] ThreadPoolExecutor
-- [ ] ProcessPoolExecutor
+- [x] ProcessPoolExecutor
 - [x] 1 single tqdm bar
-- [ ] 1 bar per worker
+- [x] 1 bar per worker
 - [x] cancel subsequent workers on failure
 - [ ] retry failed workers
 - [ ] skipping failed workers

--- a/examples/sample_1_multitqdm.py
+++ b/examples/sample_1_multitqdm.py
@@ -1,0 +1,55 @@
+"""
+This example show:
+for CPU intensive calculations,
+Threadpool doesnt actually help because of GIL
+"""
+
+def calculate_pi_monte_carlo(*, iterations):
+    """
+    Calculates an approximation of Pi using the Monte Carlo method.
+    This is a CPU-intensive task due to the large number of random
+    number generations and mathematical operations.
+    """
+    import random
+
+    points_inside_circle = 0
+    for _ in range(iterations):
+        x = random.uniform(0, 1)
+        y = random.uniform(0, 1)
+        distance = x**2 + y**2
+        if distance <= 1:
+            points_inside_circle += 1
+
+    pi_approximation = 4 * points_inside_circle / iterations
+    return pi_approximation
+
+
+
+if __name__ == "__main__":
+    print("[NOTE] use htop to monitor cpu usage.")
+    from parax import ThreadedExecutor, ProcessExecutor
+    import random
+    requests = [
+        {"iterations": random.randrange(10000,2000000)}
+        for _ in range(25)
+    ]
+
+    print("[*] thread pool executor for cpu intensive") 
+    (
+        ThreadedExecutor(
+            worker_fn=calculate_pi_monte_carlo,
+            worker_fn_kwargs=requests,
+            tqdm_description="calculating pi monte carlos [cpu bound] using threadpool..."
+        )
+        .execute()
+    )
+
+    print("[*] process pool executor for cpu intensive") 
+    (
+        ProcessExecutor(
+            worker_fn=calculate_pi_monte_carlo,
+            worker_fn_kwargs=requests,
+            tqdm_description="calculating pi monte carlos [cpu bound] using threadpool..."
+        )
+        .execute()
+    )

--- a/examples/sample_1_multitqdm.py
+++ b/examples/sample_1_multitqdm.py
@@ -39,7 +39,8 @@ if __name__ == "__main__":
         ThreadedExecutor(
             worker_fn=calculate_pi_monte_carlo,
             worker_fn_kwargs=requests,
-            tqdm_description="calculating pi monte carlos [cpu bound] using threadpool..."
+            tqdm_description="calculating pi monte carlos [cpu bound] using threadpool...",
+            tqdm_mode="multi",
         )
         .execute()
     )

--- a/examples/sample_1_multitqdm.py
+++ b/examples/sample_1_multitqdm.py
@@ -39,6 +39,7 @@ if __name__ == "__main__":
         ThreadedExecutor(
             worker_fn=calculate_pi_monte_carlo,
             worker_fn_kwargs=requests,
+            num_workers=10,
             tqdm_description="calculating pi monte carlos [cpu bound] using threadpool...",
             tqdm_mode="multi",
         )

--- a/examples/sample_1_multitqdm.py
+++ b/examples/sample_1_multitqdm.py
@@ -51,7 +51,9 @@ if __name__ == "__main__":
         ProcessExecutor(
             worker_fn=calculate_pi_monte_carlo,
             worker_fn_kwargs=requests,
-            tqdm_description="calculating pi monte carlos [cpu bound] using threadpool..."
+            num_workers=10,
+            tqdm_description="calculating pi monte carlos [cpu bound] using threadpool...",
+            tqdm_mode="multi",
         )
         .execute()
     )

--- a/parax/base.py
+++ b/parax/base.py
@@ -238,11 +238,11 @@ class BaseExecutor(ABC):
 
     def _tqdm_update(self, **kwargs):
         if self._is_tqdm_enabled():
-            if not self.tqdm_instance:
-                raise RuntimeError("Missing tqdm instance for some reason, did you call _tqdm_init()?")
-            
             match self.tqdm_mode:
                 case "normal":
+                    if not self.tqdm_instance:
+                        raise RuntimeError("Missing tqdm instance for some reason, did you call _tqdm_init()?")
+            
                     amount = kwargs.get("amount", None)
                     if not amount:
                         raise RuntimeError("tqdm update failure.")
@@ -250,6 +250,8 @@ class BaseExecutor(ABC):
                 case "multi":
                     if len(kwargs) != 2:
                         raise RuntimeError(f"Expected inputs to this function to be 2, got {len(kwargs)}")
+                    if not self.tqdm_instances:
+                        raise RuntimeError("Missing tqdm instance for some reason, did you call _tqdm_init()?")
                     amount = kwargs.get("amount", None)
                     worker_id = kwargs.get("worker_id", None)
                     if not amount:

--- a/parax/base.py
+++ b/parax/base.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 from abc import ABC, abstractmethod
 from concurrent.futures import Future, as_completed
-from typing import TYPE_CHECKING, Any, Generator, Optional, Self, Type
+from typing import TYPE_CHECKING, Any, Generator, Optional, Type
 from collections.abc import Callable
 
-from parax.decorators import apply_all_decorators
 
 if TYPE_CHECKING:
     from tqdm import tqdm
@@ -224,7 +223,7 @@ class BaseExecutor(ABC):
         return self.results
 
     def execute(self) -> BaseExecutor:
-        with self.pool_executor(max_workers=self.num_workers) as executor:
+        with self.executor_type(max_workers=self.num_workers) as executor:
             self._tqdm_init()
             for batch in self.yield_batch():
                 completed_futures: set[Future] = set()

--- a/parax/base.py
+++ b/parax/base.py
@@ -62,7 +62,7 @@ class BaseExecutor(ABC):
         tqdm_description: Optional[str] = None,
         tqdm_class: Optional[type[tqdm]] = None,
     ):
-        self.worker_fn = apply_all_decorators(worker_fn)
+        self.worker_fn = worker_fn
         self.worker_fn_kwargs = worker_fn_kwargs
         self.num_workers = num_workers or self.default_num_workers()
         self.batch_size = batch_size or self.default_batch_size()

--- a/parax/base.py
+++ b/parax/base.py
@@ -212,6 +212,8 @@ class BaseExecutor(ABC):
                         desc=self.tqdm_description,
                     )
                 case "multi":
+                    if self.num_workers > 100:
+                        print("[WARNING]: its getting to the point of this not being visually useful...")
                     self.tqdm_instances = {
                         index: self.tqdm_class(
                             position=index,
@@ -252,6 +254,17 @@ class BaseExecutor(ABC):
     def _tqdm_update(self, *, amount:int, worker_id: int):
         pass
 
+    def _init_workers_tqdm_map(self, executor: Executor):
+        """This function will perform the following.
+        
+        Initialise 1 thread/process for each worker.
+        Get the process/thread_id, and return it, we then create
+        an index -> process/thread_id map, such that we can 
+        map the process/thread_id to an index for it to update a
+        tqdm instance at that index.
+        """
+        pass 
+
     def _tqdm_close(self):
         if self._is_tqdm_enabled():
             if not self.tqdm_instance:
@@ -266,6 +279,7 @@ class BaseExecutor(ABC):
     def execute(self) -> BaseExecutor:
         with self.executor_type(max_workers=self.num_workers) as executor:
             self._tqdm_init()
+            self._init_workers_tqdm_map(executor)
             for batch in self.yield_batch():
                 completed_futures: set[Future] = set()
                 all_futures: list[Future] = [

--- a/parax/base.py
+++ b/parax/base.py
@@ -229,6 +229,12 @@ class BaseExecutor(ABC):
                     }
                 case _ :
                     raise ValueError(f"Invalid tqdm mode, expected 'normal' or 'multi', instead got {self.tqdm_mode}")
+    @overload
+    def _tqdm_update(self, *, amount:int):
+        pass
+    @overload
+    def _tqdm_update(self, *, amount:int, worker_id: int):
+        pass
 
     def _tqdm_update(self, **kwargs):
         if self._is_tqdm_enabled():
@@ -255,12 +261,7 @@ class BaseExecutor(ABC):
                     self.tqdm_instances[tqdm_index].update(amount)
         # else NOOP
 
-    @overload
-    def _tqdm_update(self, *, amount:int):
-        pass
-    @overload
-    def _tqdm_update(self, *, amount:int, worker_id: int):
-        pass
+
 
     def _init_workers_tqdm_map(self, executor: Executor):
         """This function will perform the following.
@@ -363,7 +364,7 @@ class BaseExecutor(ABC):
                 case "normal":
                     self.results.append(result)
                     completed_futures_mut.add(future)
-                    self._tqdm_update(1)
+                    self._tqdm_update(amount=1)
                 case "multi":
                     if not isinstance(result, WorkerIdAndResultPacket):
                         raise ValueError(f"Expected type: WorkerIdAndResultPacket, instead got: {type(result)}")
@@ -371,7 +372,7 @@ class BaseExecutor(ABC):
                     actual_results = result.result
                     self.results.append(actual_results) 
                     completed_futures_mut.add(future)
-                    self._tqdm_update(1, worker_id)
+                    self._tqdm_update(amount=1, worker_id=worker_id)
                 case _:
                     raise RuntimeError("This shouldn't be reachable")
 

--- a/parax/base.py
+++ b/parax/base.py
@@ -288,7 +288,7 @@ class BaseExecutor(ABC):
         ]
         worker_ids = []
         for future in as_completed(futures):
-            result = future.result
+            result = future.result()
             if not isinstance(result, WorkerIdAndResultPacket):
                 raise ValueError(f"expected type: WorkerIdAndResultPacket, instead got: {result}")
             

--- a/parax/base.py
+++ b/parax/base.py
@@ -63,7 +63,7 @@ class BaseExecutor(ABC):
         tqdm_enabled: Optional[bool] = None,
         tqdm_description: Optional[str] = None,
         tqdm_class: Optional[type[tqdm]] = None,
-        tqdm_mode: Optional[str] = None
+        tqdm_mode: Optional[Literal["normal", "multi"]] = None
     ):
         self.worker_fn = worker_fn
         self.worker_fn_kwargs = worker_fn_kwargs
@@ -212,7 +212,11 @@ class BaseExecutor(ABC):
                         desc=self.tqdm_description,
                     )
                 case "multi":
-                    raise NotImplementedError
+                    self.tqdm_instance = self.tqdm_class(
+                        nrows=self.num_workers,
+                        total=int(len(self.worker_fn_kwargs)/self.num_workers), # initialise as evenly distributed, but will update total dynamically later.
+                        desc=self.tqdm_description,
+                    )
                 case _ :
                     raise ValueError(f"Invalid tqdm mode, expected 'normal' or 'multi', instead got {self.tqdm_mode}")
 

--- a/parax/decorators.py
+++ b/parax/decorators.py
@@ -4,6 +4,7 @@
 # to a class, since that causes problems.
 
 from collections.abc import Callable
+from dataclasses import dataclass
 import functools
 from typing import Any
 
@@ -24,6 +25,11 @@ class ValidateKwargsOnly:
             raise ValueError(f"Workers must be kwargs only, detected args: {args}")
         return self.func(**kwargs)
 
+@dataclass
+class WorkerIdAndResultPacket:
+    worker_id: int
+    result: Any
+
 class ThreadAwareWorkerFunction:
     def __init__(self, func: Callable):
         self.func = func
@@ -33,7 +39,7 @@ class ThreadAwareWorkerFunction:
         import threading
         thread_id = threading.current_thread().ident
         results = self.func(**kwargs)
-        return (thread_id, results)
+        return WorkerIdAndResultPacket(worker_id=thread_id, result=results)
 
 class ProcessAwareWorkerFunction:
     def __init__(self, func: Callable):
@@ -44,7 +50,7 @@ class ProcessAwareWorkerFunction:
         import os
         process_id = os.getpid()
         results = self.func(**kwargs)
-        return (process_id, results)
+        return WorkerIdAndResultPacket(worker_id=process_id, result=results)
 
 
 

--- a/parax/decorators.py
+++ b/parax/decorators.py
@@ -54,6 +54,7 @@ class WorkerFunctionBuilder:
 
     def wrap(self, decorator: Callable):
         self.func = decorator(self.func) 
+        return self
 
     def get_function(self) -> Callable:
         return self.func

--- a/parax/decorators.py
+++ b/parax/decorators.py
@@ -60,6 +60,8 @@ class WorkerFunctionBuilder:
         return self.func
 
 
-# def apply_all_decorators(func):
-#     fn = ValidateKwargsOnly(func)
-#     return fn
+# I need a globally accessible function
+# as a worker, such that processPool doesnt break
+# i need this so I can wrap this in decorators which does stuff
+def NOOP_function():
+    pass

--- a/parax/decorators.py
+++ b/parax/decorators.py
@@ -71,3 +71,7 @@ class WorkerFunctionBuilder:
 # i need this so I can wrap this in decorators which does stuff
 def NOOP_function():
     pass
+
+def NOOP_sleep_function():
+    import time
+    time.sleep(0.5)

--- a/parax/process.py
+++ b/parax/process.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Literal, Optional
 from parax.base import BaseExecutor
 from concurrent.futures import Future, ProcessPoolExecutor, as_completed
 
@@ -23,6 +23,7 @@ class ProcessExecutor(BaseExecutor):
         tqdm_enabled: Optional[bool] = None,
         tqdm_description: Optional[str] = None,
         tqdm_class: Optional[type[tqdm]] = None,
+        tqdm_mode: Optional[Literal["normal", "multi"]] = None
     ):
         _worker_fn = (
             WorkerFunctionBuilder(worker_fn)
@@ -38,6 +39,7 @@ class ProcessExecutor(BaseExecutor):
             tqdm_enabled=tqdm_enabled,
             tqdm_description=tqdm_description,
             tqdm_class=tqdm_class,
+            tqdm_mode=tqdm_mode,
         )
 
 

--- a/parax/process.py
+++ b/parax/process.py
@@ -39,28 +39,7 @@ class ProcessExecutor(BaseExecutor):
             tqdm_class=tqdm_class,
         )
 
-    def execute(self) -> ProcessExecutor:
-        with ProcessPoolExecutor(max_workers=self.num_workers) as executor:
-            self._tqdm_init()
-            for batch in self.yield_batch():
-                completed_futures: set[Future] = set()
-                all_futures: list[Future] = [
-                    executor.submit(
-                        self.worker_fn,
-                        **kwargs_dict,
-                    )
-                    for kwargs_dict in batch
-                ]
 
-                # blocking until all futures in batch complete.
-                for future in as_completed(all_futures):
-                    self.handle_future(
-                        future=future, 
-                        all_futures=all_futures, 
-                        completed_futures_mut=completed_futures
-                    )
-                    self._tqdm_update(1)
-
-            self._tqdm_close()
-
-        return self
+    @property
+    def executor_type(self) -> type[ProcessPoolExecutor]:
+        return ProcessPoolExecutor

--- a/parax/process.py
+++ b/parax/process.py
@@ -28,6 +28,7 @@ class ProcessExecutor(BaseExecutor):
             WorkerFunctionBuilder(worker_fn)
             .wrap(ValidateKwargsOnly)
             .wrap(ProcessAwareWorkerFunction)
+            .get_function()
         )
         super().__init__(
             worker_fn=_worker_fn,

--- a/parax/process.py
+++ b/parax/process.py
@@ -4,6 +4,8 @@ from typing import TYPE_CHECKING, Any, Optional
 from parax.base import BaseExecutor
 from concurrent.futures import Future, ProcessPoolExecutor, as_completed
 
+from parax.decorators import ProcessAwareWorkerFunction, ValidateKwargsOnly, WorkerFunctionBuilder
+
 if TYPE_CHECKING:
     from tqdm import tqdm
 
@@ -22,8 +24,13 @@ class ProcessExecutor(BaseExecutor):
         tqdm_description: Optional[str] = None,
         tqdm_class: Optional[type[tqdm]] = None,
     ):
+        _worker_fn = (
+            WorkerFunctionBuilder(worker_fn)
+            .wrap(ValidateKwargsOnly)
+            .wrap(ProcessAwareWorkerFunction)
+        )
         super().__init__(
-            worker_fn=worker_fn,
+            worker_fn=_worker_fn,
             worker_fn_kwargs=worker_fn_kwargs,
             num_workers=num_workers,
             batch_size=batch_size,

--- a/parax/threading.py
+++ b/parax/threading.py
@@ -47,28 +47,6 @@ class ThreadedExecutor(BaseExecutor):
         """
         return 100 
 
-    def execute(self) -> ThreadedExecutor:
-        with ThreadPoolExecutor(max_workers=self.num_workers) as executor:
-            self._tqdm_init()
-            for batch in self.yield_batch():
-                completed_futures: set[Future] = set()
-                all_futures: list[Future] = [
-                    executor.submit(
-                        self.worker_fn,
-                        **kwargs_dict,
-                    )
-                    for kwargs_dict in batch
-                ]
-
-                # blocking until all futures in batch complete.
-                for future in as_completed(all_futures):
-                    self.handle_future(
-                        future=future, 
-                        all_futures=all_futures, 
-                        completed_futures_mut=completed_futures
-                    )
-                    self._tqdm_update(1)
-
-            self._tqdm_close()
-
-        return self
+    @property
+    def executor_type(self) -> type[ThreadPoolExecutor]:
+        return ThreadPoolExecutor

--- a/parax/threading.py
+++ b/parax/threading.py
@@ -4,6 +4,8 @@ from typing import TYPE_CHECKING, Any, Optional
 from parax.base import BaseExecutor
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 
+from parax.decorators import ThreadAwareWorkerFunction, ValidateKwargsOnly, WorkerFunctionBuilder
+
 if TYPE_CHECKING:
     from tqdm import tqdm
 
@@ -22,8 +24,13 @@ class ThreadedExecutor(BaseExecutor):
         tqdm_description: Optional[str] = None,
         tqdm_class: Optional[type[tqdm]] = None,
     ):
+        _worker_fn = (
+            WorkerFunctionBuilder(worker_fn)
+            .wrap(ValidateKwargsOnly)
+            .wrap(ThreadAwareWorkerFunction)
+        )
         super().__init__(
-            worker_fn=worker_fn,
+            worker_fn=_worker_fn,
             worker_fn_kwargs=worker_fn_kwargs,
             num_workers=num_workers,
             batch_size=batch_size,

--- a/parax/threading.py
+++ b/parax/threading.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Literal, Optional
 from parax.base import BaseExecutor
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 
@@ -23,6 +23,7 @@ class ThreadedExecutor(BaseExecutor):
         tqdm_enabled: Optional[bool] = None,
         tqdm_description: Optional[str] = None,
         tqdm_class: Optional[type[tqdm]] = None,
+        tqdm_mode: Optional[Literal["normal", "multi"]] = None
     ):
         _worker_fn = (
             WorkerFunctionBuilder(worker_fn)
@@ -38,6 +39,7 @@ class ThreadedExecutor(BaseExecutor):
             tqdm_enabled=tqdm_enabled,
             tqdm_description=tqdm_description,
             tqdm_class=tqdm_class,
+            tqdm_mode=tqdm_mode,
         )
     
     @staticmethod

--- a/parax/threading.py
+++ b/parax/threading.py
@@ -28,6 +28,7 @@ class ThreadedExecutor(BaseExecutor):
             WorkerFunctionBuilder(worker_fn)
             .wrap(ValidateKwargsOnly)
             .wrap(ThreadAwareWorkerFunction)
+            .get_function()
         )
         super().__init__(
             worker_fn=_worker_fn,


### PR DESCRIPTION
- maps each worker to a tqdm index
- on exception being raised, close all tqdm instances such that the print statements are going to actually be printed properly